### PR TITLE
Update UITouch-KIFAdditions to support new iOS 14 API

### DIFF
--- a/PTFakeTouch/addition/UITouch-KIFAdditions.h
+++ b/PTFakeTouch/addition/UITouch-KIFAdditions.h
@@ -25,6 +25,7 @@ KW_FIX_CATEGORY_BUG_H(UITouch_KIFAdditions)
 - (void)setGestureView:(UIView *)view;
 - (void)_setLocationInWindow:(CGPoint)location resetPrevious:(BOOL)resetPrevious;
 - (void)_setIsFirstTouchForView:(BOOL)firstTouchForView;
+- (void)_setIsTapToClick:(BOOL)isTapToClick;
 
 - (void)_setHidEvent:(IOHIDEventRef)event;
 

--- a/PTFakeTouch/addition/UITouch-KIFAdditions.m
+++ b/PTFakeTouch/addition/UITouch-KIFAdditions.m
@@ -29,15 +29,15 @@ typedef struct {
 
 - (id)initInView:(UIView *)view;
 {
-    CGRect frame = view.frame;    
+    CGRect frame = view.frame;
     CGPoint centerPoint = CGPointMake(frame.size.width * 0.5f, frame.size.height * 0.5f);
     return [self initAtPoint:centerPoint inView:view];
 }
 
 - (id)initAtPoint:(CGPoint)point inWindow:(UIWindow *)window;
 {
-	self = [super init];
-	if (self == nil) {
+    self = [super init];
+    if (self == nil) {
         return nil;
     }
     
@@ -47,13 +47,17 @@ typedef struct {
     //[self setTapCount:1];
     [self _setLocationInWindow:point resetPrevious:YES];
     
-	UIView *hitTestView = [window hitTest:point withEvent:nil];
+    UIView *hitTestView = [window hitTest:point withEvent:nil];
     
     [self setView:hitTestView];
     [self setPhase:UITouchPhaseBegan];
-    DLog(@"initAtPoint setPhase 0");
-    [self _setIsFirstTouchForView:YES];
-    [self setIsTap:NO];
+    NSOperatingSystemVersion iOS14 = {14, 0, 0};
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)] && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS14]) {
+        [self _setIsTapToClick:NO];
+    } else {
+        [self _setIsFirstTouchForView:YES];
+        [self setIsTap:NO];
+    }
     [self setTimestamp:[[NSProcessInfo processInfo] systemUptime]];
     if ([self respondsToSelector:@selector(setGestureView:)]) {
         [self setGestureView:hitTestView];
@@ -65,7 +69,7 @@ typedef struct {
         [self kif_setHidEvent];
     }
     
-	return self;
+    return self;
 }
 
 - (void)resetTouch{
@@ -79,11 +83,17 @@ typedef struct {
     
     UIView *hitTestView = [window hitTest:point withEvent:nil];
     
+    NSOperatingSystemVersion iOS14 = {14, 0, 0};
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)] && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS14]) {
+        [self _setIsTapToClick:NO];
+    } else {
+        [self _setIsFirstTouchForView:YES];
+        [self setIsTap:NO];
+    }
+        
     [self setView:hitTestView];
     [self setPhase:UITouchPhaseBegan];
     //DLog(@"resetTouch setPhase 0");
-    [self _setIsFirstTouchForView:YES];
-    [self setIsTap:NO];
     [self setTimestamp:[[NSProcessInfo processInfo] systemUptime]];
     if ([self respondsToSelector:@selector(setGestureView:)]) {
         [self setGestureView:hitTestView];
@@ -114,8 +124,13 @@ typedef struct {
     [self setView:hitTestView];
     [self setPhase:UITouchPhaseEnded];
     //DLog(@"init...touch...setPhase 3");
-    [self _setIsFirstTouchForView:YES];
-    [self setIsTap:NO];
+    NSOperatingSystemVersion iOS14 = {14, 0, 0};
+    if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)] && [[NSProcessInfo new] isOperatingSystemAtLeastVersion:iOS14]) {
+        [self _setIsTapToClick:NO];
+    } else {
+        [self _setIsFirstTouchForView:YES];
+        [self setIsTap:NO];
+    }
     [self setTimestamp:[[NSProcessInfo processInfo] systemUptime]];
     if ([self respondsToSelector:@selector(setGestureView:)]) {
         [self setGestureView:hitTestView];


### PR DESCRIPTION
iOS 14's UITouch headers have changed to no longer include `_setIsFirstTouchForView:(BOOL)` and `setIsTap:(BOOL)` methods, which will cause an `unrecognized selector` crash. I update the code to support the latest changes in iOS14's UITouch headers.

This has been tested on the following iOS versions:

- `iOS 14.3`
- `iOS 13.1.3`
- `iOS 13.4`

I will continue to test on a few more versions later tonight.